### PR TITLE
clone - adding option to choose an endpoint prefix.

### DIFF
--- a/ditto/clone.py
+++ b/ditto/clone.py
@@ -12,8 +12,7 @@ def do_clone(base_url, target_dir, replacement_url):
 
     def print_json(data, file_name):
         transformed_data = json.dumps(data, indent=4, sort_keys=True)
-        if replacement_url:
-            transformed_data = transformed_data.replace(base_url, replacement_url)
+        transformed_data = transformed_data.replace(base_url, replacement_url)
         print(transformed_data, file=safe_open_w(file_name))
 
     if not base_url.endswith("/"):

--- a/ditto/clone.py
+++ b/ditto/clone.py
@@ -4,14 +4,17 @@ import os.path
 import requests
 
 
-def do_clone(base_url, target_dir):
+def do_clone(base_url, target_dir, replacement_url):
 
     def safe_open_w(file_name):
         os.makedirs(os.path.dirname(file_name), exist_ok=True)
         return open(file_name, "w")
 
     def print_json(data, file_name):
-        print(json.dumps(data, indent=4, sort_keys=True), file=safe_open_w(file_name))
+        transformed_data = json.dumps(data, indent=4, sort_keys=True)
+        if replacement_url:
+            transformed_data = transformed_data.replace(base_url, replacement_url)
+        print(transformed_data, file=safe_open_w(file_name))
 
     if not base_url.endswith("/"):
         base_url += "/"

--- a/ditto/main.py
+++ b/ditto/main.py
@@ -13,6 +13,7 @@ class Ditto(object):
         transform = subparsers.add_parser('clone')
         transform.add_argument('--source', type=str, default='http://localhost/')
         transform.add_argument('--destination', type=str, default='./data')
+        transform.add_argument('--replacement-url', type=str, default='https://pokeapi.co/')
 
         serve = subparsers.add_parser('serve')
         serve.add_argument('--port', type=int, default=80)
@@ -25,7 +26,7 @@ class Ditto(object):
 
     @staticmethod
     def clone(args):
-        clone.do_clone(args.source, args.destination)
+        clone.do_clone(args.source, args.destination, args.replacement_url)
 
     @staticmethod
     def serve(args):


### PR DESCRIPTION
<strikeout>**Untested**. </strikeout>

Tested with `build_languages()` and `data/language/` directory.

E.g.:

```diff
diff --git a/data/api/v2/language/3/index.json b/data/api/v2/language/3/index.json
index 4a5e6a20..fbcf381d 100644
--- a/data/api/v2/language/3/index.json
+++ b/data/api/v2/language/3/index.json
@@ -6,29 +6,29 @@
     "names": [
         {
             "language": {
-                "name": "ja",
-                "url": "http://localhost/api/v2/language/1/"
+                "name": "ja-Hrkt",
+                "url": "https://pokeapi.co/api/v2/language/1/"
             },
             "name": "\u97d3\u56fd\u8a9e"
         },
         {
             "language": {
                 "name": "fr",
-                "url": "http://localhost/api/v2/language/5/"
+                "url": "https://pokeapi.co/api/v2/language/5/"
             },
             "name": "Cor\u00e9en"
         },
         {
             "language": {
                 "name": "de",
-                "url": "http://localhost/api/v2/language/6/"
+                "url": "https://pokeapi.co/api/v2/language/6/"
             },
             "name": "Koreanisch"
         },
         {
             "language": {
                 "name": "en",
-                "url": "http://localhost/api/v2/language/9/"
+                "url": "https://pokeapi.co/api/v2/language/9/"
             },
             "name": "Korean"
         }

```